### PR TITLE
Close response body

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/go-playground/validator/v10"
-	"golang.org/x/time/rate"
 	"net/http"
 	"net/url"
+
+	"github.com/go-playground/validator/v10"
+	"golang.org/x/time/rate"
 )
 
 var _ Transporter = (*Client)(nil)
@@ -117,7 +118,7 @@ func (c *Client) Post(ctx context.Context, apiConfig *APIConfig, apiRequest any)
 	if err != nil {
 		return nil, err
 	}
-
+	defer resp.Body.Close()
 	return &Response{resp}, nil
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -79,7 +79,7 @@ func (c *Client) Get(ctx context.Context, apiConfig *APIConfig) (*Response, erro
 	if err != nil {
 		return nil, err
 	}
-
+	defer resp.Body.Close()
 	return &Response{resp}, nil
 }
 


### PR DESCRIPTION
This commit adds a defer statement to close the response body after processing in the Get and Post method of the Client struct to prevent potential resource leaks